### PR TITLE
Update GitHub link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,7 +11,7 @@ theme = 'cleanmaths'
 
   [[params.social]]
       title = "GitHub"
-      link = "https://github.com/jack4818/SQISign-SageMath"
+      link = "https://github.com/LearningToSQI/SQISign-SageMath"
       icon = "/images/github.svg"
 
 [markup]

--- a/themes/cleanmaths/theme.toml
+++ b/themes/cleanmaths/theme.toml
@@ -11,4 +11,4 @@ min_version = "0.41.0"
 
 [author]
   name = "Giacomo Pope"
-  homepage = "learningtosqi.github.io"
+  homepage = "jack4818.github.io"

--- a/themes/cleanmaths/theme.toml
+++ b/themes/cleanmaths/theme.toml
@@ -11,4 +11,4 @@ min_version = "0.41.0"
 
 [author]
   name = "Giacomo Pope"
-  homepage = "jack4818.github.io"
+  homepage = "learningtosqi.github.io"


### PR DESCRIPTION
![Screenshot from 2023-08-28 14-17-31](https://github.com/LearningToSQI/learningtosqi.github.io/assets/83517584/4296fb87-b9f1-4042-bd84-a48fac36004f)

Change this thing called "GitHub" (not sure what that is)

Sorry wait I changed the wrong thing, give me a second